### PR TITLE
Fix dashboard submission by including user ID in links

### DIFF
--- a/src/services/CommandService.ts
+++ b/src/services/CommandService.ts
@@ -83,8 +83,10 @@ export class CommandService {
         return await this.handleSetupSupervisors(command);
       }
 
-      // สร้างลิงก์ Dashboard (ทุกคนในกลุ่มสามารถใช้ได้)
-      const dashboardUrl = UrlBuilder.getDashboardUrl(command.groupId);
+      // สร้างลิงก์ Dashboard พร้อมระบุตัวตนผู้ใช้เพื่อใช้งานฟีเจอร์ที่ต้องการ userId
+      const dashboardUrl = UrlBuilder.getDashboardUrl(command.groupId, {
+        userId: command.userId
+      });
 
       return `🔧 Dashboard เลขาบอท
 
@@ -222,7 +224,7 @@ ${supervisorNames}
         FlexMessageDesignSystem.createButton(
           'เปิด Dashboard กลุ่ม',
           'uri',
-          UrlBuilder.getDashboardUrl(command.groupId),
+          UrlBuilder.getDashboardUrl(command.groupId, { userId: command.userId }),
           'secondary'
         )
       ];


### PR DESCRIPTION
## Summary
- append `userId` to dashboard URLs generated by commands so the web interface can identify users

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a44d4af3ec83318fc33927c41f950b