### PR TITLE
feat: generate group-scoped file URLs

### DIFF
--- a/src/controllers/webhookController.ts
+++ b/src/controllers/webhookController.ts
@@ -939,7 +939,11 @@ class WebhookController {
                   const fileData = file[0];
                   response += `📄 ${fileData.originalName}\n`;
                   response += `📦 ${this.formatFileSize(fileData.size)}\n`;
-                  response += `👤 ${fileData.uploadedByUser?.displayName || 'ไม่ทราบ'}\n\n`;
+                  response += `👤 ${fileData.uploadedByUser?.displayName || 'ไม่ทราบ'}\n`;
+                  if (fileData.linkedTasks && fileData.linkedTasks.length > 0) {
+                    response += `📋 มาจากงาน: ${fileData.linkedTasks[0].title}\n`;
+                  }
+                  response += `\n`;
                 }
               } catch (error) {
                 console.error('Error getting file:', error);

--- a/src/services/FlexMessageTemplateService.ts
+++ b/src/services/FlexMessageTemplateService.ts
@@ -5,6 +5,8 @@ import { FlexMessageDesignSystem, TaskCardData } from './FlexMessageDesignSystem
 import { FlexMessage } from '@line/bot-sdk';
 import moment from 'moment';
 import { config } from '@/utils/config';
+import { serviceContainer } from '@/utils/serviceContainer';
+import { FileService } from './FileService';
 
 export class FlexMessageTemplateService {
   /**
@@ -594,10 +596,11 @@ export class FlexMessageTemplateService {
       ] : [])
     ];
 
+    const fileService = serviceContainer.get<FileService>('FileService');
     const buttons = [
-      FlexMessageDesignSystem.createButton('📥', 'uri', `${config.baseUrl}/api/files/${file.id}/download`, 'primary'),
+      FlexMessageDesignSystem.createButton('📥', 'uri', fileService.generateDownloadUrl(group.id, file.id), 'primary'),
       ...(this.isPreviewable(file.mimeType) ? [
-        FlexMessageDesignSystem.createButton('👁️', 'uri', `${config.baseUrl}/api/files/${file.id}/preview`, 'secondary')
+        FlexMessageDesignSystem.createButton('👁️', 'uri', fileService.generatePreviewUrl(group.id, file.id), 'secondary')
       ] : [])
     ];
 
@@ -652,11 +655,12 @@ export class FlexMessageTemplateService {
     ];
 
     // สร้างปุ่มสำหรับไฟล์แต่ละไฟล์ (สูงสุด 3 ไฟล์แรก)
-    const fileButtons = files.slice(0, 3).map(file => 
+    const fileService = serviceContainer.get<FileService>('FileService');
+    const fileButtons = files.slice(0, 3).map(file =>
       FlexMessageDesignSystem.createButton(
-        `📥 ${file.originalName.substring(0, 8)}...`, 
-        'uri', 
-        `${config.baseUrl}/api/files/${file.id}/download`, 
+        `📥 ${file.originalName.substring(0, 8)}...`,
+        'uri',
+        fileService.generateDownloadUrl(group.id, file.id),
         'primary'
       )
     );
@@ -811,11 +815,12 @@ export class FlexMessageTemplateService {
     ];
 
     // สร้างปุ่มสำหรับไฟล์แต่ละไฟล์ (สูงสุด 3 ไฟล์แรก)
-    const fileButtons = files.slice(0, 3).map(file => 
+    const fileService = serviceContainer.get<FileService>('FileService');
+    const fileButtons = files.slice(0, 3).map(file =>
       FlexMessageDesignSystem.createButton(
-        `📥 ${file.originalName.substring(0, 10)}...`, 
-        'uri', 
-        `${config.baseUrl}/api/files/${file.id}/download`, 
+        `📥 ${file.originalName.substring(0, 10)}...`,
+        'uri',
+        fileService.generateDownloadUrl(file.groupId, file.id),
         'secondary'
       )
     );
@@ -867,11 +872,12 @@ export class FlexMessageTemplateService {
     ];
 
     // สร้างปุ่มสำหรับไฟล์แต่ละไฟล์ (สูงสุด 3 ไฟล์แรก)
-    const fileButtons = files.slice(0, 3).map(file => 
+    const fileService = serviceContainer.get<FileService>('FileService');
+    const fileButtons = files.slice(0, 3).map(file =>
       FlexMessageDesignSystem.createButton(
-        `📥 ${file.originalName.substring(0, 8)}...`, 
-        'uri', 
-        `${config.baseUrl}/api/files/${file.id}/download`, 
+        `📥 ${file.originalName.substring(0, 8)}...`,
+        'uri',
+        fileService.generateDownloadUrl(file.groupId, file.id),
         'secondary'
       )
     );
@@ -1024,11 +1030,12 @@ export class FlexMessageTemplateService {
     ];
 
     // สร้างปุ่มสำหรับไฟล์แต่ละไฟล์ (สูงสุด 3 ไฟล์แรก)
-    const fileButtons = files.slice(0, 3).map(file => 
+    const fileService = serviceContainer.get<FileService>('FileService');
+    const fileButtons = files.slice(0, 3).map(file =>
       FlexMessageDesignSystem.createButton(
-        `📥 ${file.originalName.substring(0, 8)}...`, 
-        'uri', 
-        `${config.baseUrl}/api/files/${file.id}/download`, 
+        `📥 ${file.originalName.substring(0, 8)}...`,
+        'uri',
+        fileService.generateDownloadUrl(file.groupId, file.id),
         'secondary'
       )
     );

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -345,9 +345,6 @@ export class NotificationService {
       FlexMessageDesignSystem.createText(`👤 ผู้ส่ง: ${submitterDisplayName}`, 'sm', FlexMessageDesignSystem.colors.textPrimary),
       ...(fileCount > 0 ? [
         FlexMessageDesignSystem.createText(`📎 ไฟล์แนบ: ${fileCount} รายการ`, 'sm', FlexMessageDesignSystem.colors.textPrimary, 'bold'),
-        ...files.slice(0, 2).map(file => [
-          FlexMessageDesignSystem.createText(`• ${file.originalName}`, 'xs', FlexMessageDesignSystem.colors.textSecondary)
-        ]).flat(),
         ...(files.length > 2 ? [
           FlexMessageDesignSystem.createText(`และอีก ${files.length - 2} ไฟล์...`, 'xs', FlexMessageDesignSystem.colors.textSecondary)
         ] : [])
@@ -359,11 +356,23 @@ export class NotificationService {
       FlexMessageDesignSystem.createText('📅 กำหนดตรวจภายใน: 2 วัน', 'sm', FlexMessageDesignSystem.colors.textSecondary)
     ];
 
+    const fileButtons = fileCount > 0
+      ? files.slice(0, 2).map(file =>
+          FlexMessageDesignSystem.createButton(
+            `📥 ${file.originalName.substring(0, 8)}...`,
+            'uri',
+            this.fileService.generateDownloadUrl(group.id, file.id),
+            'secondary'
+          )
+        )
+      : [];
+
     const buttons = [
       FlexMessageDesignSystem.createButton('ดูรายละเอียด', 'uri', `${config.baseUrl}/dashboard?groupId=${group.id}&taskId=${task.id}`, 'primary'),
       ...(fileCount > 0 ? [
         FlexMessageDesignSystem.createButton('ดูไฟล์แนบทั้งหมด', 'postback', `action=show_task_files&taskId=${task.id}&groupId=${group.id}`, 'secondary')
-      ] : [])
+      ] : []),
+      ...fileButtons
     ];
 
     return FlexMessageDesignSystem.createStandardTaskCard(

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -608,7 +608,7 @@ export class TaskService {
       const saved = await this.taskRepository.save(task);
 
       // เตรียมลิงก์ไฟล์สำหรับผู้ตรวจ
-      const fileLinks = fileIds.map(fid => this.fileService.generateDownloadUrl(fid));
+      const fileLinks = fileIds.map(fid => this.fileService.generateDownloadUrl(task.group.id, fid));
 
       // แจ้งผู้ตรวจให้ตรวจภายใน 2 วัน
       try {


### PR DESCRIPTION
## Summary
- scope file URLs by group in FileService and templates
- include download buttons with group-aware links in task submission notifications
- use group-aware URLs when notifying reviewers
- show originating task name for personal chat file submissions

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a47243956c8331a807f6daa2ea09be