### PR TITLE
fix: refresh unknown display names

### DIFF
--- a/src/controllers/webhookController.ts
+++ b/src/controllers/webhookController.ts
@@ -1253,6 +1253,23 @@ class WebhookController {
         }
       } else {
         console.log(`ℹ️ ผู้ใช้มีอยู่ในฐานข้อมูลแล้ว: ${user.displayName}`);
+
+        // หากชื่อผู้ใช้ยังเป็นค่าเริ่มต้น เช่น "ไม่ทราบ" ให้ลองอัปเดตอีกครั้งจาก LINE
+        const unknownNames = ['ไม่ทราบ', 'ผู้ใช้ไม่ทราบชื่อ', ''];
+        if (unknownNames.includes(user.displayName)) {
+          try {
+            const profile = await this.lineService.getUserProfile(userId);
+            if (profile.displayName && !unknownNames.includes(profile.displayName)) {
+              await this.userService.updateUser(user.id, {
+                displayName: profile.displayName,
+                realName: profile.displayName
+              });
+              console.log(`🔄 อัปเดตชื่อผู้ใช้จาก 'ไม่ทราบ' เป็น ${profile.displayName}`);
+            }
+          } catch (error) {
+            console.warn('⚠️ ไม่สามารถอัปเดตชื่อผู้ใช้จาก LINE API ได้:', error);
+          }
+        }
       }
     } catch (error) {
       console.error('❌ Error ensuring user exists:', error);

--- a/src/services/LineService.ts
+++ b/src/services/LineService.ts
@@ -928,8 +928,31 @@ export class LineService {
       
       if (existingMember) {
         console.log(`ℹ️ สมาชิก ${existingMember.displayName} มีอยู่ในฐานข้อมูลแล้ว`);
+
+        // หากชื่อผู้ใช้ยังเป็นค่าเริ่มต้น เช่น "ไม่ทราบ" ให้พยายามดึงข้อมูลจาก LINE อีกครั้ง
+        const unknownNames = ['ไม่ทราบ', 'ผู้ใช้ไม่ทราบชื่อ', ''];
+        if (unknownNames.includes(existingMember.displayName)) {
+          try {
+            const profile = await this.client.getProfile(userId);
+            if (profile.displayName && !unknownNames.includes(profile.displayName)) {
+              const userEntity = await this.userService.findByLineUserId(userId);
+              if (userEntity) {
+                await this.userService.updateUser(userEntity.id, {
+                  displayName: profile.displayName,
+                  realName: profile.displayName
+                });
+                existingMember.displayName = profile.displayName;
+                console.log(`🔄 อัปเดตชื่อผู้ใช้จาก 'ไม่ทราบ' เป็น ${profile.displayName}`);
+              }
+            }
+          } catch (error) {
+            console.warn('⚠️ ไม่สามารถอัปเดตชื่อผู้ใช้จาก LINE API ได้:', error);
+          }
+        }
+
         return {
-          isNewMember: false
+          isNewMember: false,
+          memberInfo: existingMember
         };
       }
       


### PR DESCRIPTION
## Summary
- refresh user display names when existing member name is unknown
- attempt to pull and store latest display name for personal chats

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a482d92a748331aa4b5bb73015ff1c