### PR TITLE
feat: add comprehensive migration orchestrator

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:fix-kpi-foreign-key": "tsx src/scripts/fixKpiRecordsForeignKey.ts",
     "db:check-kpi-foreign-keys": "tsx src/scripts/checkKpiForeignKeys.ts",
     "db:check-schema": "tsx src/scripts/checkDatabaseSchema.ts",
+    "db:migrate-all": "tsx src/scripts/runFullMigration.ts",
     "test:rules": "tsx src/scripts/testProjectRules.ts",
     "test": "jest",
     "lint": "eslint src --ext .ts",

--- a/src/scripts/addMissingTaskStatusEnum.ts
+++ b/src/scripts/addMissingTaskStatusEnum.ts
@@ -92,3 +92,5 @@ if (require.main === module) {
       process.exit(1);
     });
 }
+
+export { addMissingTaskStatusEnum };

--- a/src/scripts/runFullMigration.ts
+++ b/src/scripts/runFullMigration.ts
@@ -1,0 +1,49 @@
+import { logger } from '@/utils/logger';
+import { addMissingColumns } from './addMissingColumns';
+import { addMissingTaskStatusEnum } from './addMissingTaskStatusEnum';
+import { migrateTaskWorkflow } from './migrateTaskWorkflow';
+import { updateTaskStatuses } from './updateTaskStatuses';
+import { updateAllMembersToAdmin } from './updateAllMembersToAdmin';
+import { updateGroupSettingsForSupervisors } from './updateGroupSettingsForSupervisors';
+import { fixUnknownDisplayNames } from './fixUnknownDisplayNames';
+import { fixKpiRecordsForeignKey } from './fixKpiRecordsForeignKey';
+import { checkDatabaseSchema } from './checkDatabaseSchema';
+import { checkKpiForeignKeys } from './checkKpiForeignKeys';
+
+async function runFullMigration() {
+  const steps: { name: string; fn: () => Promise<void> }[] = [
+    { name: 'Add missing task status enum', fn: addMissingTaskStatusEnum },
+    { name: 'Add missing columns', fn: addMissingColumns },
+    { name: 'Migrate task workflow', fn: migrateTaskWorkflow },
+    { name: 'Update task statuses', fn: updateTaskStatuses },
+    { name: 'Update all members to admin', fn: updateAllMembersToAdmin },
+    { name: 'Update group settings for supervisors', fn: updateGroupSettingsForSupervisors },
+    { name: 'Fix unknown display names', fn: fixUnknownDisplayNames },
+    { name: 'Fix KPI records foreign key', fn: fixKpiRecordsForeignKey },
+    { name: 'Check database schema', fn: checkDatabaseSchema },
+    { name: 'Check KPI foreign keys', fn: checkKpiForeignKeys }
+  ];
+
+  logger.info('🚀 Starting full migration process...');
+
+  for (const step of steps) {
+    try {
+      logger.info(`\n➡️  ${step.name}`);
+      await step.fn();
+      logger.info(`✅ Completed: ${step.name}`);
+    } catch (error) {
+      logger.error(`❌ Step failed: ${step.name}`, error);
+      throw error;
+    }
+  }
+
+  logger.info('\n🎉 All migration steps completed successfully');
+}
+
+if (require.main === module) {
+  runFullMigration()
+    .then(() => process.exit(0))
+    .catch(() => process.exit(1));
+}
+
+export { runFullMigration };

--- a/src/scripts/updateGroupSettingsForSupervisors.ts
+++ b/src/scripts/updateGroupSettingsForSupervisors.ts
@@ -53,10 +53,18 @@ async function updateGroupSettingsForSupervisors() {
       await AppDataSource.destroy();
       console.log('🔌 Database connection closed');
     }
-    
-    process.exit(0);
   }
 }
 
-// รัน migration
-updateGroupSettingsForSupervisors();
+// รัน migration ถ้าเรียกไฟล์นี้โดยตรง
+if (require.main === module) {
+  updateGroupSettingsForSupervisors()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch(() => {
+      process.exit(1);
+    });
+}
+
+export { updateGroupSettingsForSupervisors };

--- a/src/scripts/updateTaskStatuses.ts
+++ b/src/scripts/updateTaskStatuses.ts
@@ -84,3 +84,5 @@ if (require.main === module) {
       process.exit(1);
     });
 }
+
+export { updateTaskStatuses };


### PR DESCRIPTION
## Summary
- add runFullMigration script to execute all database migrations sequentially
- expose individual migration scripts for reuse
- wire new full migration into npm scripts

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a3a82914833182d264c2563250d8