### PR TITLE
feat: handle google oauth callback

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -21,6 +21,7 @@ export class Group {
     reminderIntervals: string[];
     enableLeaderboard: boolean;
     googleCalendarId?: string;
+    googleRefreshToken?: string;
     defaultReminders: string[];
     workingHours: {
       start: string;

--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -57,6 +57,17 @@ export class GoogleCalendarService {
   }
 
   /**
+   * ตั้งค่า OAuth credentials หลังจากแลกเปลี่ยน token แล้ว
+   */
+  public setCredentials(tokens: any): void {
+    try {
+      this.auth?.setCredentials(tokens);
+    } catch (error) {
+      console.error('❌ Error setting OAuth credentials:', error);
+    }
+  }
+
+  /**
    * สร้าง Calendar ใหม่สำหรับกลุ่ม
    */
   public async createGroupCalendar(groupName: string, timezone: string = config.app.defaultTimezone): Promise<string> {

--- a/src/services/GoogleService.ts
+++ b/src/services/GoogleService.ts
@@ -1,9 +1,11 @@
 // Google Service - รวมบริการต่างๆ ของ Google
 
+import { google } from 'googleapis';
 import { GoogleCalendarService } from './GoogleCalendarService';
 import { UserService } from './UserService';
 import { Task, Group, User } from '@/types';
 import { Task as TaskEntity } from '@/models';
+import { config } from '@/utils/config';
 
 export class GoogleService {
   private calendarService: GoogleCalendarService;
@@ -249,13 +251,24 @@ export class GoogleService {
    */
   public async handleOAuthCallback(code: string, groupId: string): Promise<void> {
     try {
-      // TODO: Implement OAuth token exchange
-      // 1. แลกเปลี่ยน code กับ access token
-      // 2. เก็บ refresh token ในฐานข้อมูล
-      // 3. ตั้งค่า credentials สำหรับ API calls
-      
-      console.log('📝 TODO: Implement OAuth callback handling');
+      const oauth2Client = new google.auth.OAuth2(
+        config.google.clientId,
+        config.google.clientSecret,
+        config.google.redirectUri
+      );
 
+      const { tokens } = await oauth2Client.getToken(code);
+      if (!tokens.refresh_token) {
+        throw new Error('No refresh token returned from Google');
+      }
+
+      await this.userService.updateGroupSettings(groupId, {
+        googleRefreshToken: tokens.refresh_token
+      });
+
+      this.calendarService.setCredentials(tokens);
+
+      console.log('✅ Google OAuth credentials set for group');
     } catch (error) {
       console.error('❌ Error handling OAuth callback:', error);
       throw error;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export interface GroupSettings {
   reminderIntervals: string[]; // เช่น ['7d', '1d', '3h']
   enableLeaderboard: boolean;
   googleCalendarId?: string;
+  googleRefreshToken?: string;
   defaultReminders: string[];
   workingHours: {
     start: string; // 'HH:mm'


### PR DESCRIPTION
## Summary
- exchange authorization codes for Google tokens
- store group refresh token and set credentials for calendar API
- expose helper to apply OAuth tokens in GoogleCalendarService

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a9c8fb108331a83263294e072001