### PR TITLE
Share group calendar with task participants

### DIFF
--- a/src/services/GoogleService.test.ts
+++ b/src/services/GoogleService.test.ts
@@ -1,0 +1,37 @@
+import { GoogleService } from './GoogleService';
+import { GoogleCalendarService } from './GoogleCalendarService';
+import { UserService } from './UserService';
+
+jest.mock('./GoogleCalendarService');
+jest.mock('./UserService');
+
+describe('GoogleService.shareCalendarWithMembers', () => {
+  it('shares calendar with all specified participants', async () => {
+    const mockCalendarService = {
+      shareCalendarWithUser: jest.fn().mockResolvedValue(undefined)
+    } as unknown as GoogleCalendarService;
+
+    const mockUserService = {
+      findGroupById: jest.fn().mockResolvedValue({
+        id: 'g1',
+        settings: { googleCalendarId: 'cal-1' }
+      }),
+      getGroupMembers: jest.fn().mockResolvedValue([
+        { id: 'u1', email: 'u1@example.com', isVerified: true, role: 'member' },
+        { id: 'u2', email: 'u2@example.com', isVerified: true, role: 'admin' },
+        { id: 'u3', email: 'u3@example.com', isVerified: true, role: 'member' }
+      ])
+    } as unknown as UserService;
+
+    (GoogleCalendarService as unknown as jest.Mock).mockImplementation(() => mockCalendarService);
+    (UserService as unknown as jest.Mock).mockImplementation(() => mockUserService);
+
+    const service = new GoogleService();
+    await service.shareCalendarWithMembers('g1', ['u1', 'u2']);
+
+    expect(mockCalendarService.shareCalendarWithUser).toHaveBeenCalledTimes(2);
+    expect(mockCalendarService.shareCalendarWithUser).toHaveBeenCalledWith('cal-1', 'u1@example.com', 'reader');
+    expect(mockCalendarService.shareCalendarWithUser).toHaveBeenCalledWith('cal-1', 'u2@example.com', 'writer');
+  });
+});
+

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -198,6 +198,21 @@ export class TaskService {
           // อัปเดต task ด้วย eventId
           savedTask.googleEventId = eventId;
           await this.taskRepository.save(savedTask);
+
+          // แชร์ปฏิทินกับผู้เกี่ยวข้อง (ผู้สร้าง ผู้รับผิดชอบ ผู้ตรวจ)
+          const participantIds = new Set<string>();
+          participantIds.add(creator.id);
+          if (reviewerInternalId) participantIds.add(reviewerInternalId);
+          if (savedTask.assignedUsers) {
+            for (const user of savedTask.assignedUsers) {
+              participantIds.add(user.id);
+            }
+          }
+
+          await this.googleService.shareCalendarWithMembers(
+            group.id,
+            Array.from(participantIds)
+          );
         }
       } catch (error) {
         console.warn('⚠️ Failed to sync task to Google Calendar:', error);


### PR DESCRIPTION
## Summary
- Auto-share new group calendars with existing members
- Share calendars with task creators, reviewers and assignees
- Test that calendar ACL entries are created for all participants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ad24d0508331aef83053450361d7