### PR TITLE
feat(cron): prevent duplicate job creation

### DIFF
--- a/src/services/CronService.test.ts
+++ b/src/services/CronService.test.ts
@@ -1,0 +1,34 @@
+// Mock dependencies that require external services or databases
+jest.mock('./TaskService', () => ({ TaskService: jest.fn(() => ({})) }));
+jest.mock('./NotificationService', () => ({ NotificationService: jest.fn(() => ({})) }));
+jest.mock('./KPIService', () => ({ KPIService: jest.fn(() => ({})) }));
+
+const scheduleMock = jest.fn(() => ({ start: jest.fn(), stop: jest.fn() }));
+
+jest.mock('node-cron', () => ({
+  schedule: scheduleMock,
+}));
+
+import { CronService } from './CronService';
+
+describe('CronService.start', () => {
+  beforeEach(() => {
+    scheduleMock.mockClear();
+  });
+
+  it('avoids creating duplicate jobs when called twice', () => {
+    const service = new CronService();
+    const stopSpy = jest.spyOn(service, 'stop');
+
+    service.start();
+    const jobCount = (service as any).jobs.size;
+    expect(scheduleMock).toHaveBeenCalledTimes(jobCount);
+
+    service.start();
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(scheduleMock).toHaveBeenCalledTimes(jobCount * 2);
+    expect((service as any).jobs.size).toBe(jobCount);
+  });
+});
+

--- a/src/services/CronService.ts
+++ b/src/services/CronService.ts
@@ -16,6 +16,7 @@ export class CronService {
   private notificationService: NotificationService;
   private kpiService: KPIService;
   private jobs: Map<string, cron.ScheduledTask> = new Map();
+  private isStarted = false;
 
   constructor() {
     this.taskService = new TaskService();
@@ -24,6 +25,11 @@ export class CronService {
   }
 
   public start(): void {
+    if (this.isStarted) {
+      console.log('🔄 Cron jobs already running, restarting...');
+      this.stop();
+    }
+
     console.log('🕐 Starting cron jobs...');
 
     // เตือนก่อนถึงกำหนด 1 วัน: รันทุกชั่วโมงเพื่อตรวจช่วง 1 วันก่อน
@@ -115,6 +121,8 @@ export class CronService {
       job.start();
       console.log(`✅ Started cron job: ${name}`);
     });
+
+    this.isStarted = true;
   }
 
   public stop(): void {
@@ -126,6 +134,7 @@ export class CronService {
     });
     
     this.jobs.clear();
+    this.isStarted = false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `isStarted` flag to CronService to avoid duplicate cron jobs and restart safely
- add unit test verifying repeated `start()` calls don't create duplicates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad88cf888331a7b15a2606ac4c92