### PR TITLE
Use verified emails for Google Calendar attendees

### DIFF
--- a/src/services/GoogleCalendarService.test.ts
+++ b/src/services/GoogleCalendarService.test.ts
@@ -1,0 +1,66 @@
+import { GoogleCalendarService } from './GoogleCalendarService';
+import { Task } from '@/types';
+
+jest.mock('googleapis', () => ({
+  google: {
+    calendar: jest.fn().mockReturnValue({}),
+    auth: {
+      OAuth2: jest.fn().mockImplementation(() => ({})),
+      GoogleAuth: jest.fn().mockImplementation(() => ({})),
+    },
+  },
+}));
+
+describe('GoogleCalendarService.getTaskAttendees', () => {
+  beforeAll(() => {
+    process.env.GOOGLE_CLIENT_ID = 'id';
+    process.env.GOOGLE_CLIENT_SECRET = 'secret';
+    process.env.GOOGLE_REDIRECT_URI = 'http://localhost';
+  });
+
+  it('returns only verified emails for interface tasks', async () => {
+    const mockUserService = {
+      findById: jest.fn((id: string) => {
+        if (id === '1') {
+          return Promise.resolve({ id: '1', email: 'a@example.com', isVerified: true, displayName: 'User A' });
+        }
+        if (id === '2') {
+          return Promise.resolve({ id: '2', email: 'b@example.com', isVerified: false, displayName: 'User B' });
+        }
+        return Promise.resolve(null);
+      }),
+    } as any;
+
+    const service = new GoogleCalendarService(mockUserService);
+    const task = { assignees: ['1', '2'] } as Task;
+    const attendees = await (service as any).getTaskAttendees(task);
+
+    expect(attendees).toEqual([
+      { email: 'a@example.com', displayName: 'User A' },
+    ]);
+    expect(mockUserService.findById).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns verified emails for entity tasks', async () => {
+    const mockUserService = {
+      findById: jest.fn((id: string) => {
+        const users: Record<string, any> = {
+          '1': { id: '1', email: 'a@example.com', isVerified: true, displayName: 'User A' },
+          '2': { id: '2', email: 'b@example.com', isVerified: true, displayName: 'User B' },
+          '3': { id: '3', email: 'c@example.com', isVerified: false, displayName: 'User C' },
+        };
+        return Promise.resolve(users[id] || null);
+      }),
+    } as any;
+
+    const service = new GoogleCalendarService(mockUserService);
+    const task: any = { assignedUsers: [{ id: '1' }, { id: '2' }, { id: '3' }] };
+    const attendees = await (service as any).getTaskAttendees(task);
+
+    expect(attendees).toEqual([
+      { email: 'a@example.com', displayName: 'User A' },
+      { email: 'b@example.com', displayName: 'User B' },
+    ]);
+    expect(mockUserService.findById).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- fetch actual attendee emails from UserService when creating calendar events
- include only verified users in attendee list
- add tests confirming attendees array uses verified emails

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ad1fc05c833194387dfc782d9661