### PR TITLE
feat(task): include reviewer and creator emails

### DIFF
--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -100,9 +100,15 @@ export class GoogleCalendarService {
   /**
    * สร้าง Event จากงาน
    */
-  public async createTaskEvent(task: Task | TaskEntity, calendarId: string): Promise<string> {
+  public async createTaskEvent(
+    task: Task | TaskEntity,
+    calendarId: string,
+    attendeeEmails?: string[]
+  ): Promise<string> {
     try {
-      const attendees = await this.getTaskAttendees(task);
+      const attendees = attendeeEmails
+        ? attendeeEmails.map(email => ({ email }))
+        : await this.getTaskAttendees(task);
       const event: GoogleCalendarEvent = {
         summary: task.title,
         description: this.formatEventDescription(task),

--- a/src/services/GoogleService.ts
+++ b/src/services/GoogleService.ts
@@ -48,14 +48,22 @@ export class GoogleService {
   /**
    * ซิงค์งานไปยัง Google Calendar
    */
-  public async syncTaskToCalendar(task: Task | TaskEntity, groupCalendarId: string): Promise<string> {
+  public async syncTaskToCalendar(
+    task: Task | TaskEntity,
+    groupCalendarId: string,
+    attendeeEmails?: string[]
+  ): Promise<string> {
     try {
       if (!groupCalendarId) {
         throw new Error('Group calendar not configured');
       }
 
       // สร้าง Event ใน Calendar
-      const eventId = await this.calendarService.createTaskEvent(task, groupCalendarId);
+      const eventId = await this.calendarService.createTaskEvent(
+        task,
+        groupCalendarId,
+        attendeeEmails
+      );
       
       // คืนค่า eventId เพื่อให้ TaskService update เอง (หลีกเลี่ยง circular dependency)
       return eventId;


### PR DESCRIPTION
## Summary
- add UserService to TaskService and fetch creator/reviewer emails for calendar sync
- pass deduped attendee emails to GoogleService and GoogleCalendarService

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a4af3e87b483318baf0b0b7f87460b