### PR TITLE
Redirect to cloud-hosted files in download and preview APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@typescript-eslint/parser": "^6.9.1",
         "eslint": "^8.52.0",
         "jest": "^29.7.0",
+        "supertest": "^6.3.3",
         "ts-jest": "^29.1.1",
         "tsc-alias": "^1.8.16",
         "tsx": "^4.1.2",
@@ -1742,6 +1743,19 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1778,6 +1792,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2560,6 +2584,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3206,6 +3237,16 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3269,6 +3310,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -3433,6 +3481,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -4061,6 +4120,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4273,6 +4339,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -7803,6 +7885,57 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@typescript-eslint/parser": "^6.9.1",
     "eslint": "^8.52.0",
     "jest": "^29.7.0",
+    "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
     "tsc-alias": "^1.8.16",
     "tsx": "^4.1.2",

--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -527,6 +527,20 @@ class ApiController {
         }
       }
 
+      const file = await this.fileService.getFileInfo(fileId);
+      if (!file) {
+        res.status(404).json({
+          success: false,
+          error: 'File not found'
+        });
+        return;
+      }
+
+      if (/^https?:\/\//.test(file.path)) {
+        res.redirect(file.path);
+        return;
+      }
+
       const { content, mimeType, originalName } = await this.fileService.getFileContent(fileId);
 
       res.set({
@@ -580,6 +594,20 @@ class ApiController {
           });
           return;
         }
+      }
+
+      const file = await this.fileService.getFileInfo(fileId);
+      if (!file) {
+        res.status(404).json({
+          success: false,
+          error: 'File not found'
+        });
+        return;
+      }
+
+      if (/^https?:\/\//.test(file.path)) {
+        res.redirect(file.path);
+        return;
       }
 
       const { content, mimeType } = await this.fileService.getFileContent(fileId);

--- a/src/controllers/fileRoutes.test.ts
+++ b/src/controllers/fileRoutes.test.ts
@@ -1,0 +1,65 @@
+import express from 'express';
+import request from 'supertest';
+
+describe('File route redirection', () => {
+  const setup = async (fileInfo: any) => {
+    jest.resetModules();
+    const { serviceContainer } = await import('@/utils/serviceContainer');
+    serviceContainer.clear();
+
+    const mockFileService = {
+      isFileInGroup: jest.fn().mockResolvedValue(true),
+      getFileInfo: jest.fn().mockResolvedValue(fileInfo),
+      getFileContent: jest.fn()
+    };
+
+    const stubNames = [
+      'TaskService',
+      'UserService',
+      'KPIService',
+      'RecurringTaskService',
+      'LineService',
+      'NotificationCardService'
+    ];
+    for (const name of stubNames) {
+      (serviceContainer as any).services.set(name, {});
+    }
+    (serviceContainer as any).services.set('FileService', mockFileService);
+
+    const { apiRouter } = await import('@/controllers/apiController');
+    const app = express();
+    app.use('/', apiRouter);
+
+    return { app, mockFileService };
+  };
+
+  it('redirects downloadFile to remote URL', async () => {
+    const url = 'https://example.com/test-image.jpg';
+    const { app, mockFileService } = await setup({
+      id: '1',
+      path: url,
+      mimeType: 'image/jpeg',
+      originalName: 'test-image.jpg'
+    });
+
+    const res = await request(app).get('/files/1/download');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(url);
+    expect(mockFileService.getFileContent).not.toHaveBeenCalled();
+  });
+
+  it('redirects previewFile to remote URL', async () => {
+    const url = 'https://example.com/test.pdf';
+    const { app, mockFileService } = await setup({
+      id: '2',
+      path: url,
+      mimeType: 'application/pdf',
+      originalName: 'test.pdf'
+    });
+
+    const res = await request(app).get('/files/2/preview');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(url);
+    expect(mockFileService.getFileContent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Redirect `downloadFile` to remote URLs when file path is an HTTP link
- Redirect `previewFile` to remote URLs when file path is an HTTP link
- Add tests verifying image and PDF requests are redirected

## Testing
- `npm test` *(fails: NotificationService tests unable to initialize email service)*
- `npx jest src/controllers/fileRoutes.test.ts`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68abb7955ff88331a865920a4b4e3bfd