### PR TITLE
Handle missing files in download and preview endpoints

### DIFF
--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -551,7 +551,6 @@ class ApiController {
       }
 
       const file = await this.fileService.getFileInfo(fileId);
-      fileUrl = file.path;
       if (!file) {
         res.status(404).json({
           success: false,
@@ -559,6 +558,7 @@ class ApiController {
         });
         return;
       }
+      fileUrl = file.path;
 
       // Debug: log ข้อมูลไฟล์
       logger.info(`🔍 Download file: ${fileId}, path: ${file.path}, mimeType: ${file.mimeType}`);
@@ -788,7 +788,6 @@ class ApiController {
       }
 
       const file = await this.fileService.getFileInfo(fileId);
-      fileUrl = file.path;
       if (!file) {
         res.status(404).json({
           success: false,
@@ -796,6 +795,7 @@ class ApiController {
         });
         return;
       }
+      fileUrl = file.path;
 
       // Debug: log ข้อมูลไฟล์
       logger.info(`🔍 Preview file: ${fileId}, path: ${file.path}, mimeType: ${file.mimeType}`);


### PR DESCRIPTION
## Summary
- Move `fileUrl` assignment after null checks in `downloadFile` and `previewFile`
- Return 404 if file lookup returns null to avoid exceptions

## Testing
- `npm test` *(fails: NotificationService tests and file route redirection tests)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b81f5e083319546a96fc6359e4a