### PR TITLE
Validate file types on upload

### DIFF
--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -951,13 +951,28 @@ class ApiController {
         return;
       }
 
-      // ตรวจสอบว่าไฟล์มีขนาดเกิน limit หรือไม่
+      const ALLOWED_MIME_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/gif',
+        'application/pdf',
+        'text/plain'
+      ];
+
+      // ตรวจสอบว่าไฟล์มีขนาดเกิน limit หรือประเภทไม่ถูกต้อง
       const maxFileSize = config.storage.maxFileSize || 10 * 1024 * 1024; // 10MB default
       for (const file of files) {
+        if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+          res.status(400).json({
+            success: false,
+            error: `Invalid file type: ${file.mimetype}`
+          });
+          return;
+        }
         if (file.size > maxFileSize) {
-          res.status(400).json({ 
-            success: false, 
-            error: `File ${file.originalname} is too large. Maximum size is ${Math.round(maxFileSize / 1024 / 1024)}MB` 
+          res.status(400).json({
+            success: false,
+            error: `File ${file.originalname} is too large. Maximum size is ${Math.round(maxFileSize / 1024 / 1024)}MB`
           });
           return;
         }

--- a/src/controllers/uploadFiles.test.ts
+++ b/src/controllers/uploadFiles.test.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import request from 'supertest';
+import { serviceContainer } from '@/utils/serviceContainer';
+
+describe('uploadFiles', () => {
+  const setup = async () => {
+    serviceContainer.clear();
+
+    const mockFileService = {
+      saveFile: jest.fn(),
+      addFileTags: jest.fn()
+    };
+
+    const stubNames = [
+      'TaskService',
+      'UserService',
+      'KPIService',
+      'RecurringTaskService',
+      'LineService',
+      'NotificationCardService'
+    ];
+    for (const name of stubNames) {
+      (serviceContainer as any).services.set(name, {});
+    }
+    (serviceContainer as any).services.set('FileService', mockFileService);
+
+    const { apiRouter } = await import('./apiController');
+    const app = express();
+    app.use('/', apiRouter);
+
+    return { app };
+  };
+
+  it('rejects disallowed file types', async () => {
+    const { app } = await setup();
+
+    const res = await request(app)
+      .post('/groups/group1/files/upload')
+      .field('userId', 'user1')
+      .attach('attachments', Buffer.from('test'), {
+        filename: 'malware.exe',
+        contentType: 'application/x-msdownload'
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toMatch(/Invalid file type/);
+  });
+});


### PR DESCRIPTION
## Summary
- validate uploaded files against allowed MIME types in uploadFiles
- add tests for rejecting disallowed file types

## Testing
- `npm test` *(fails: NotificationService tests and uploadFiles test)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b7528308331baa3582e5e1974bd