### PR TITLE
Handle nullable ORM finds in TaskService

### DIFF
--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -701,15 +701,19 @@ export class TaskService {
     let submitter: User;
 
     try {
-      task = await queryRunner.manager.findOne(Task, {
+      const foundTask = await queryRunner.manager.findOne(Task, {
         where: { id: taskId },
         relations: ['assignedUsers', 'group', 'attachedFiles']
       });
-      if (!task) throw new Error('Task not found');
+      if (!foundTask) throw new Error('Task not found');
+      task = foundTask;
 
       // แปลง LINE → internal user id
-      submitter = await queryRunner.manager.findOne(User, { where: { lineUserId: submitterLineUserId } });
-      if (!submitter) throw new Error('Submitter not found');
+      const foundSubmitter = await queryRunner.manager.findOne(User, {
+        where: { lineUserId: submitterLineUserId }
+      });
+      if (!foundSubmitter) throw new Error('Submitter not found');
+      submitter = foundSubmitter;
 
       // ผูกไฟล์เข้ากับงานและอัปเดตข้อมูลไฟล์
       for (const fid of fileIds) {


### PR DESCRIPTION
## Summary
- guard `findOne` results for Task and User to satisfy strict typing

## Testing
- `npm run build`
- `npm test` *(fails: Failed to initialize email service, disabling email notifications; File route redirection assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e05f1808331b4511549c0463a15