### PR TITLE
fix: correct cloudinary url signing

### DIFF
--- a/src/services/FileService.test.ts
+++ b/src/services/FileService.test.ts
@@ -58,14 +58,16 @@ describe('FileService.saveFile', () => {
 });
 
 describe('FileService.resolveFileUrl', () => {
-  it('signs Cloudinary URLs', () => {
+  beforeEach(() => {
     process.env.CLOUDINARY_CLOUD_NAME = 'demo';
     process.env.CLOUDINARY_API_KEY = 'key';
     process.env.CLOUDINARY_API_SECRET = 'secret';
-
+    urlMock.mockClear();
     getRepositoryMock.mockReset();
     getRepositoryMock.mockImplementation(() => ({} as any));
+  });
 
+  it('signs Cloudinary URLs with correct resource type and version', () => {
     const { FileService } = require('./FileService');
     const service = new FileService();
 
@@ -77,7 +79,39 @@ describe('FileService.resolveFileUrl', () => {
     };
 
     const result = service.resolveFileUrl(file);
-    expect(urlMock).toHaveBeenCalledWith('publicid', expect.objectContaining({ sign_url: true }));
+    expect(urlMock).toHaveBeenCalledWith(
+      'publicid',
+      expect.objectContaining({
+        resource_type: 'raw',
+        type: 'upload',
+        version: '1',
+        sign_url: true,
+        secure: true,
+      })
+    );
     expect(result).toBe('https://signed-url');
+  });
+
+  it('handles URLs with signature segments', () => {
+    const { FileService } = require('./FileService');
+    const service = new FileService();
+
+    const file: any = {
+      path: 'https://res.cloudinary.com/demo/image/upload/s--abc--/v1/folder/file.jpg',
+      mimeType: 'image/jpeg',
+      storageProvider: 'cloudinary',
+      storageKey: 'folder/file',
+    };
+
+    service.resolveFileUrl(file);
+    expect(urlMock).toHaveBeenLastCalledWith(
+      'folder/file',
+      expect.objectContaining({
+        resource_type: 'image',
+        type: 'upload',
+        version: '1',
+        sign_url: true,
+      })
+    );
   });
 });

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -680,9 +680,23 @@ export class FileService {
 
       const urlObj = new URL(file.path);
       const parts = urlObj.pathname.split('/').filter(Boolean);
+
+      // Remove cloud name segment if present
+      if (parts[0] === config.cloudinary.cloudName) {
+        parts.shift();
+      }
+
       const resourceType = parts[0] || 'image';
       const deliveryType = parts[1] || 'upload';
-      const version = parts[2]?.startsWith('v') ? parts[2].substring(1) : undefined;
+
+      // Find version segment (e.g., v1)
+      let version: string | undefined;
+      for (let i = 2; i < parts.length; i++) {
+        if (parts[i].startsWith('v')) {
+          version = parts[i].substring(1);
+          break;
+        }
+      }
 
       const publicId = file.storageKey || file.fileName;
       const options: any = {


### PR DESCRIPTION
## Summary
- fix Cloudinary URL signing by stripping cloud name and parsing version segment
- add tests for Cloudinary URL parsing including signature segments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb9c69a688331983bc633b82168c4