### PR TITLE
Append file extension to Cloudinary public ID

### DIFF
--- a/src/services/FileService.test.ts
+++ b/src/services/FileService.test.ts
@@ -75,12 +75,12 @@ describe('FileService.resolveFileUrl', () => {
       path: 'https://res.cloudinary.com/demo/raw/upload/v1/publicid.pdf',
       mimeType: 'application/pdf',
       storageProvider: 'cloudinary',
-      storageKey: 'publicid',
+      storageKey: 'publicid.pdf',
     };
 
     const result = service.resolveFileUrl(file);
     expect(urlMock).toHaveBeenCalledWith(
-      'publicid',
+      'publicid.pdf',
       expect.objectContaining({
         resource_type: 'raw',
         type: 'upload',
@@ -100,12 +100,12 @@ describe('FileService.resolveFileUrl', () => {
       path: 'https://res.cloudinary.com/demo/image/upload/s--abc--/v1/folder/file.jpg',
       mimeType: 'image/jpeg',
       storageProvider: 'cloudinary',
-      storageKey: 'folder/file',
+      storageKey: 'folder/file.jpg',
     };
 
     service.resolveFileUrl(file);
     expect(urlMock).toHaveBeenLastCalledWith(
-      'folder/file',
+      'folder/file.jpg',
       expect.objectContaining({
         resource_type: 'image',
         type: 'upload',

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -96,7 +96,7 @@ export class FileService {
         const base64 = data.content.toString('base64');
         const ext = this.getFileExtension(data.mimeType, data.originalName);
         const folder = `${config.cloudinary.uploadFolder}/${data.groupId}`;
-        const publicId = `${Date.now()}_${crypto.randomBytes(6).toString('hex')}`;
+        const publicId = `${Date.now()}_${crypto.randomBytes(6).toString('hex')}${ext}`;
         const resourceType = data.mimeType.startsWith('application/') ? 'raw' : 'auto';
         const uploadRes = await cloudinary.uploader.upload(`data:${data.mimeType};base64,${base64}` as any, {
           folder,
@@ -107,12 +107,12 @@ export class FileService {
         fileRecord = this.fileRepository.create({
           groupId: internalGroupId,
           originalName: data.originalName || `file_${data.messageId}${ext}`,
-          fileName: uploadRes.public_id,
+          fileName: publicId,
           mimeType: data.mimeType,
           size: uploadRes.bytes || data.content.length,
           path: uploadRes.secure_url, // เก็บเป็น URL
           storageProvider: 'cloudinary',
-          storageKey: uploadRes.public_id,
+          storageKey: publicId,
           uploadedBy: internalUserId,
           isPublic: false,
           tags: [],


### PR DESCRIPTION
## Summary
- include file extension in generated Cloudinary public ID
- persist Cloudinary storage key and filename with extension
- adjust tests for new Cloudinary public ID format

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acce151a10833199759d06c44c91a6