### PR TITLE
feat: support office document uploads

### DIFF
--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -875,6 +875,7 @@ class ApiController {
 
   /**
    * POST /api/groups/:groupId/files/upload - อัปโหลดไฟล์เข้าคลังไฟล์ของกลุ่มโดยตรง
+   * รองรับไฟล์รูปภาพ (JPEG, PNG, GIF), PDF, ข้อความธรรมดา และไฟล์เอกสาร Microsoft Office (Word, Excel, PowerPoint)
    * form-data fields: userId (LINE User ID), comment (optional), tags (comma-separated, optional)
    */
   public async uploadFiles(req: Request, res: Response): Promise<void> {
@@ -897,7 +898,10 @@ class ApiController {
         'image/png',
         'image/gif',
         'application/pdf',
-        'text/plain'
+        'text/plain',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation'
       ];
 
       // ตรวจสอบว่าไฟล์มีขนาดเกิน limit หรือประเภทไม่ถูกต้อง
@@ -906,7 +910,7 @@ class ApiController {
         if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
           res.status(400).json({
             success: false,
-            error: `Invalid file type: ${file.mimetype}`
+            error: `Invalid file type: ${file.mimetype}. Allowed types: ${ALLOWED_MIME_TYPES.join(', ')}`
           });
           return;
         }


### PR DESCRIPTION
## Summary
- allow uploading Word, Excel, and PowerPoint files
- clarify allowed MIME types in file upload errors
- test office document upload

## Testing
- `npm test -- src/controllers/uploadFiles.test.ts`
- `npx eslint src/controllers/apiController.ts src/controllers/uploadFiles.test.ts` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68acce1da584833192fb03eef4656a3e