### PR TITLE
feat: add filename fallback for downloads

### DIFF
--- a/dashboard/script.js
+++ b/dashboard/script.js
@@ -3107,7 +3107,32 @@ class Dashboard {
             }
           }
         }
-        
+
+        // หากไม่มี Content-Disposition หรือไม่สามารถดึงชื่อไฟล์ได้
+        if (filename === 'download') {
+          try {
+            // พยายามดึงข้อมูลไฟล์จาก API เพื่อเอา originalName
+            const infoRes = await fetch(`${this.apiBase}/api/groups/${this.currentGroupId}/files/${fileId}`);
+            if (infoRes.ok) {
+              let fileData = await infoRes.json();
+              if (fileData && typeof fileData === 'object' && 'data' in fileData) {
+                fileData = fileData.data;
+              }
+              if (fileData && fileData.originalName) {
+                filename = fileData.originalName;
+              }
+            }
+          } catch (err) {
+            console.warn('Failed to fetch file info for filename:', err);
+          }
+
+          // หากยังไม่ได้ชื่อไฟล์ ให้ลองใช้ข้อมูลจาก UI
+          if (filename === 'download') {
+            const nameFromUI = document.querySelector(`[data-file-id="${fileId}"] .file-name`)?.textContent?.trim();
+            if (nameFromUI) filename = nameFromUI;
+          }
+        }
+
         a.download = filename;
         a.click();
         window.URL.revokeObjectURL(url);


### PR DESCRIPTION
## Summary
- handle missing filename when downloading files by fetching original name or using UI data
- ensure download attribute preserves file extension

## Testing
- `npm test` *(fails: FileService.resolveFileUrl expectations)*
- `npm run lint` *(fails: ESLint configuration not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acce1f6ec88331917a16bba5fbbd54