### PR TITLE
Use FileService for download extension

### DIFF
--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -570,11 +570,11 @@ class ApiController {
       // ตรวจสอบและสร้างชื่อไฟล์ที่เหมาะสม
       let downloadName = originalName && originalName.trim() !== '' ? originalName : `file_${fileId}`;
 
-      // เพิ่มนามสกุลหากชื่อไฟล์ไม่มี
-      if (!/\.[A-Za-z0-9]{1,8}$/i.test(downloadName)) {
-        const ext = (this.fileService as any).getFileExtension
-          ? (this.fileService as any).getFileExtension(mimeType, originalName)
-          : '';
+      // เพิ่มนามสกุลให้ถูกต้อง
+      const ext = (this.fileService as any).getFileExtension
+        ? (this.fileService as any).getFileExtension(mimeType, downloadName)
+        : '';
+      if (ext && !downloadName.toLowerCase().endsWith(ext.toLowerCase())) {
         downloadName += ext;
       }
 

--- a/src/controllers/fileRoutes.test.ts
+++ b/src/controllers/fileRoutes.test.ts
@@ -58,6 +58,7 @@ describe('File route handling', () => {
     expect(res.headers['content-disposition']).toContain('filename="test-image.jpg"');
     expect(res.body).toEqual(content);
     expect(mockFileService.getFileContent).toHaveBeenCalledWith('1');
+    expect(mockFileService.getFileExtension).toHaveBeenCalledWith('image/jpeg', 'test-image');
   });
 
   it('redirects previewFile to remote URL', async () => {


### PR DESCRIPTION
## Summary
- rely on FileService.getFileExtension to append file extension in downloads
- assert extension helper usage in file route tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd03774f48331b1d98a7714394b61