### PR TITLE
Limit reminders to 1 day and 3 hours with time-left notice

### DIFF
--- a/src/services/CronService.ts
+++ b/src/services/CronService.ts
@@ -583,13 +583,11 @@ export class CronService {
    * แปลงช่วงเวลาการเตือนเป็นหน่วยและจำนวน
    */
   private parseReminderInterval(interval: string): { amount: number; unit: moment.DurationInputArg2 } {
-    if (interval === 'P7D' || interval === '7d') return { amount: 7, unit: 'days' };
     if (interval === 'P1D' || interval === '1d') return { amount: 1, unit: 'days' };
     if (interval === 'PT3H' || interval === '3h') return { amount: 3, unit: 'hours' };
     // เอาการเตือนตอนเช้า 08:00 น. ออกไปแล้ว
     // if (interval === 'daily_8am') return { amount: 0, unit: 'days' };
-    if (interval === 'due') return { amount: 0, unit: 'minutes' };
-    
+
     // ค่าเริ่มต้น
     return { amount: 1, unit: 'days' };
   }

--- a/src/services/EmailService.ts
+++ b/src/services/EmailService.ts
@@ -214,10 +214,6 @@ export class EmailService {
     
     let reminderText = '';
     switch (reminderType) {
-      case 'P7D':
-      case '7d':
-        reminderText = 'อีก 7 วัน';
-        break;
       case 'P1D':
       case '1d':
         reminderText = 'พรุ่งนี้';
@@ -225,9 +221,6 @@ export class EmailService {
       case 'PT3H':
       case '3h':
         reminderText = 'อีก 3 ชั่วโมง';
-        break;
-      case 'due':
-        reminderText = 'ถึงเวลาแล้ว';
         break;
       default:
         reminderText = 'เตือนล่วงหน้า';
@@ -275,7 +268,7 @@ export class EmailService {
             ` : ''}
             
             <div class="label">📅 กำหนดส่ง:</div>
-            <div class="value ${reminderType === 'due' ? 'urgent' : ''}">${dueTime}</div>
+            <div class="value">${dueTime}</div>
             
             <div class="label">⏰ การเตือน:</div>
             <div class="value">${reminderText}</div>

--- a/src/services/GoogleCalendarService.ts
+++ b/src/services/GoogleCalendarService.ts
@@ -361,9 +361,7 @@ export class GoogleCalendarService {
     return reminders.map(reminder => {
       let minutes = 60; // default 1 hour
 
-      if (reminder.includes('P7D') || reminder === '7d') {
-        minutes = 7 * 24 * 60; // 7 days
-      } else if (reminder.includes('P1D') || reminder === '1d') {
+      if (reminder.includes('P1D') || reminder === '1d') {
         minutes = 24 * 60; // 1 day
       } else if (reminder.includes('PT3H') || reminder === '3h') {
         minutes = 3 * 60; // 3 hours

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -473,13 +473,19 @@ export class NotificationService {
    * สร้าง Flex Message สำหรับการเตือนงาน
    */
   private createTaskReminderFlexMessage(task: any, group: any, reminderType: string): FlexMessage {
-    const reminderText = this.getReminderTimeText(reminderType);
     const reminderEmoji = this.getReminderEmoji(reminderType);
-    const dueDate = moment(task.dueTime).tz(config.app.defaultTimezone).format('DD/MM/YYYY HH:mm');
+    const now = moment().tz(config.app.defaultTimezone);
+    const dueMoment = moment(task.dueTime).tz(config.app.defaultTimezone);
+    const remaining = moment.duration(dueMoment.diff(now));
+    const remainingText = remaining.asDays() >= 1
+      ? `${Math.floor(remaining.asDays())} วัน${remaining.hours() > 0 ? ` ${remaining.hours()} ชั่วโมง` : ''}`
+      : `${remaining.hours()} ชั่วโมง`;
+    const dueDate = dueMoment.format('DD/MM/YYYY HH:mm');
     const assigneeNames = (task.assignedUsers || []).map((u: any) => u.displayName).join(', ') || 'ไม่ระบุ';
 
     const content = [
       FlexMessageDesignSystem.createText(`📅 กำหนดส่ง: ${dueDate}`, 'sm', FlexMessageDesignSystem.colors.textPrimary),
+      FlexMessageDesignSystem.createText(`⏳ เหลือเวลาอีก ${remainingText}`, 'sm', FlexMessageDesignSystem.colors.textSecondary),
       FlexMessageDesignSystem.createText(`👥 ผู้รับผิดชอบ: ${assigneeNames}`, 'sm', FlexMessageDesignSystem.colors.textPrimary),
       FlexMessageDesignSystem.createText(`🎯 ${this.getPriorityText(task.priority)}`, 'sm', this.getPriorityColor(task.priority), 'bold'),
       ...(task.description ? [FlexMessageDesignSystem.createText(`📝 ${task.description}`, 'sm', FlexMessageDesignSystem.colors.textSecondary, undefined, true)] : [])
@@ -505,10 +511,17 @@ export class NotificationService {
   private createPersonalTaskReminderFlexMessage(task: any, group: any, assignee: any, reminderType: string): FlexMessage {
     const reminderText = this.getReminderTimeText(reminderType);
     const reminderEmoji = this.getReminderEmoji(reminderType);
-    const dueDate = moment(task.dueTime).tz(config.app.defaultTimezone).format('DD/MM/YYYY HH:mm');
+    const now = moment().tz(config.app.defaultTimezone);
+    const dueMoment = moment(task.dueTime).tz(config.app.defaultTimezone);
+    const remaining = moment.duration(dueMoment.diff(now));
+    const remainingText = remaining.asDays() >= 1
+      ? `${Math.floor(remaining.asDays())} วัน${remaining.hours() > 0 ? ` ${remaining.hours()} ชั่วโมง` : ''}`
+      : `${remaining.hours()} ชั่วโมง`;
+    const dueDate = dueMoment.format('DD/MM/YYYY HH:mm');
 
     const content = [
       FlexMessageDesignSystem.createText(`📅 กำหนดส่ง: ${dueDate}`, 'sm', FlexMessageDesignSystem.colors.textPrimary),
+      FlexMessageDesignSystem.createText(`⏳ เหลือเวลาอีก ${remainingText}`, 'sm', FlexMessageDesignSystem.colors.textSecondary),
       FlexMessageDesignSystem.createText(`🎯 ${this.getPriorityText(task.priority)}`, 'sm', this.getPriorityColor(task.priority), 'bold'),
       ...(task.description ? [FlexMessageDesignSystem.createText(`📝 ${task.description}`, 'sm', FlexMessageDesignSystem.colors.textSecondary, undefined, true)] : [])
     ];
@@ -869,17 +882,12 @@ export class NotificationService {
    */
   private getReminderTimeText(reminderType: string): string {
     switch (reminderType) {
-      case 'P7D':
-      case '7d':
-        return 'อีก 7 วัน';
       case 'P1D':
       case '1d':
         return 'พรุ่งนี้';
       case 'PT3H':
       case '3h':
         return 'อีก 3 ชั่วโมง';
-      case 'due':
-        return 'ถึงเวลาแล้ว';
       default:
         return 'เตือนความจำ';
     }
@@ -890,17 +898,12 @@ export class NotificationService {
    */
   private getReminderEmoji(reminderType: string): string {
     switch (reminderType) {
-      case 'P7D':
-      case '7d':
-        return '📅';
       case 'P1D':
       case '1d':
         return '⏰';
       case 'PT3H':
       case '3h':
         return '⚡';
-      case 'due':
-        return '🚨';
       default:
         return '🔔';
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ export interface Group {
 }
 
 export interface GroupSettings {
-  reminderIntervals: string[]; // เช่น ['7d', '1d', '3h']
+  reminderIntervals: string[]; // เช่น ['1d', '3h']
   enableLeaderboard: boolean;
   googleCalendarId?: string;
   googleRefreshToken?: string;
@@ -81,7 +81,7 @@ export interface Task {
 }
 
 export interface ReminderLog {
-  type: string; // '7d', '1d', '3h', 'due'
+  type: string; // '1d', '3h'
   sentAt: Date;
   channels: ('line' | 'email')[];
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -67,8 +67,8 @@ export const config = {
     defaultTimezone: process.env.DEFAULT_TIMEZONE || 'Asia/Bangkok',
     
     // Default reminder intervals (in ISO 8601 duration format)
-    // ปรับตาม requirement: เตือนก่อนถึงกำหนด 1 วัน
-    defaultReminders: ['P1D'],
+    // ปรับตาม requirement: เตือนก่อนถึงกำหนด 1 วัน และ 3 ชั่วโมง
+    defaultReminders: ['P1D', 'PT3H'],
     
     // KPI Scoring (0-100 scale)
     kpiScoring: {


### PR DESCRIPTION
## Summary
- show remaining time in reminder cards and personal reminders
- restrict reminder intervals to one day and three hours across services

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68acd3b06fe083318ac15af4f50bb812