### PR TITLE
fix: show PDFs inline in dashboard

### DIFF
--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -667,8 +667,8 @@ class ApiController {
   private async fallbackToPreviewFile(fileId: string, res: Response): Promise<void> {
     try {
       logger.info(`🔄 Fallback: ดึงไฟล์ ${fileId} ผ่าน getFileContent สำหรับ preview`);
-      const { content, mimeType } = await this.fileService.getFileContent(fileId);
-      
+      const { content, mimeType, originalName } = await this.fileService.getFileContent(fileId);
+
       // รองรับเฉพาะไฟล์ที่ดูตัวอย่างได้
       const previewableMimes = [
         'image/jpeg', 'image/png', 'image/gif', 'image/webp',
@@ -676,16 +676,28 @@ class ApiController {
       ];
 
       if (!previewableMimes.includes(mimeType)) {
-        res.status(400).json({ 
-          success: false, 
-          error: 'File type not previewable' 
+        res.status(400).json({
+          success: false,
+          error: 'File type not previewable'
         });
         return;
       }
 
+      // ตรวจสอบและสร้างชื่อไฟล์ที่เหมาะสมสำหรับ header
+      let previewName = originalName && originalName.trim() !== '' ? originalName : `file_${fileId}`;
+      const ext = (this.fileService as any).getFileExtension
+        ? (this.fileService as any).getFileExtension(mimeType, previewName)
+        : '';
+      if (ext && !previewName.toLowerCase().endsWith(ext.toLowerCase())) {
+        previewName += ext;
+      }
+      previewName = sanitize(previewName);
+      const encodedName = encodeURIComponent(previewName);
+
       res.set({
         'Content-Type': mimeType,
-        'Content-Length': content.length.toString()
+        'Content-Length': content.length.toString(),
+        'Content-Disposition': `inline; filename="${previewName}"; filename*=UTF-8''${encodedName}`
       });
 
       res.send(content);
@@ -747,29 +759,41 @@ class ApiController {
         return;
       }
 
-      // ถ้าเป็น URL แต่ streaming ไม่สำเร็จ หรือไม่ใช่ URL: ดึงเนื้อไฟล์ผ่าน service
-      const { content, mimeType } = await this.fileService.getFileContent(fileId);
+        // ถ้าเป็น URL แต่ streaming ไม่สำเร็จ หรือไม่ใช่ URL: ดึงเนื้อไฟล์ผ่าน service
+        const { content, mimeType, originalName } = await this.fileService.getFileContent(fileId);
 
-      // รองรับเฉพาะไฟล์ที่ดูตัวอย่างได้
-      const previewableMimes = [
-        'image/jpeg', 'image/png', 'image/gif', 'image/webp',
-        'application/pdf', 'text/plain'
-      ];
+        // รองรับเฉพาะไฟล์ที่ดูตัวอย่างได้
+        const previewableMimes = [
+          'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+          'application/pdf', 'text/plain'
+        ];
 
-      if (!previewableMimes.includes(mimeType)) {
-        res.status(400).json({ 
-          success: false, 
-          error: 'File type not previewable' 
+        if (!previewableMimes.includes(mimeType)) {
+          res.status(400).json({
+            success: false,
+            error: 'File type not previewable'
+          });
+          return;
+        }
+
+        // ตรวจสอบและสร้างชื่อไฟล์สำหรับ header
+        let previewName = originalName && originalName.trim() !== '' ? originalName : `file_${fileId}`;
+        const ext = (this.fileService as any).getFileExtension
+          ? (this.fileService as any).getFileExtension(mimeType, previewName)
+          : '';
+        if (ext && !previewName.toLowerCase().endsWith(ext.toLowerCase())) {
+          previewName += ext;
+        }
+        previewName = sanitize(previewName);
+        const encodedName = encodeURIComponent(previewName);
+
+        res.set({
+          'Content-Type': mimeType,
+          'Content-Length': content.length.toString(),
+          'Content-Disposition': `inline; filename="${previewName}"; filename*=UTF-8''${encodedName}`
         });
-        return;
-      }
 
-      res.set({
-        'Content-Type': mimeType,
-        'Content-Length': content.length.toString()
-      });
-
-      res.send(content);
+        res.send(content);
 
     } catch (error) {
       const statusCode = (error as any)?.statusCode;

--- a/src/controllers/fileRoutes.test.ts
+++ b/src/controllers/fileRoutes.test.ts
@@ -75,4 +75,26 @@ describe('File route handling', () => {
     expect(res.headers.location).toBe(url);
     expect(mockFileService.getFileContent).not.toHaveBeenCalled();
   });
+
+  it('streams file content for previewFile', async () => {
+    const content = Buffer.from('pdf-content');
+    const { app, mockFileService } = await setup({
+      id: '3',
+      path: '/local/path/file',
+      mimeType: 'application/pdf',
+      originalName: 'test'
+    });
+    mockFileService.getFileExtension.mockReturnValue('.pdf');
+    mockFileService.getFileContent.mockResolvedValue({
+      content,
+      mimeType: 'application/pdf',
+      originalName: 'test'
+    });
+
+    const res = await request(app).get('/files/3/preview');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/pdf');
+    expect(res.body).toEqual(content);
+    expect(mockFileService.getFileContent).toHaveBeenCalledWith('3');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure preview route sends inline Content-Disposition with proper file extension
- cover preview streaming with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acd34a067483318bb9dca846b3c7e4