### PR TITLE
Fix group file listing route and task file linking

### DIFF
--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -4022,7 +4022,8 @@ apiRouter.get('/groups/:groupId/stats', apiController.getGroupStats.bind(apiCont
 apiRouter.get('/groups/:groupId/tasks', validateRequest(taskSchemas.list), apiController.getTasks.bind(apiController));
 apiRouter.post('/groups/:groupId/tasks', validateRequest(taskSchemas.create), apiController.createTask.bind(apiController));
 apiRouter.get('/groups/:groupId/calendar', apiController.getCalendarEvents.bind(apiController));
-apiRouter.get('/groups/:groupId/files', apiController.getFiles.bind(apiController));
+// Group file listing should respect the requested group rather than defaulting to "default"
+apiRouter.get('/groups/:groupId/files', apiController.getGroupFiles.bind(apiController));
 apiRouter.get('/groups/:groupId/leaderboard', apiController.getLeaderboard.bind(apiController));
 apiRouter.post('/groups/:groupId/sync-leaderboard', apiController.syncLeaderboard.bind(apiController));
 apiRouter.get('/users/:userId/score-history/:groupId', apiController.getUserScoreHistory.bind(apiController));
@@ -4056,11 +4057,6 @@ apiRouter.get('/groups/:groupId/files/:fileId', apiController.getFileInfo.bind(a
 apiRouter.get('/groups/:groupId/tasks/:taskId/files', 
   validateTaskId,
   apiController.getTaskFiles.bind(apiController)
-);
-
-// Group files endpoint (public access for dashboard)
-apiRouter.get('/groups/:groupId/files',
-  apiController.getGroupFiles.bind(apiController)
 );
 
 // User and export routes


### PR DESCRIPTION
## Summary
- register the group files endpoint with `getGroupFiles` so it returns files for the requested group and remove the duplicate route
- update file-to-task linking to operate from the owning `Task.attachedFiles` relation with proper existence checks and matching unlink logic
- enhance the dashboard task detail modal to aggregate attachment sources so creation-time files appear even when no submissions exist

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df21297fa8833295af68c5f8d72b3a