### PR TITLE
Fix group file retrieval and submission attachment handling

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1146,7 +1146,7 @@
                                 <p class="text-gray-600 mb-1">ลากไฟล์มาวางที่นี่ หรือคลิกเพื่อเลือกไฟล์</p>
                                 <p class="text-sm text-gray-500">รองรับไฟล์ทุกประเภท สูงสุด 10 ไฟล์</p>
                             </div>
-                            <input type="file" id="submitTaskFiles" name="files" multiple style="display: none;">
+                            <input type="file" id="submitTaskFiles" name="attachments" multiple style="display: none;">
                         </div>
                         <div id="submitFileList" class="file-list hidden mt-3">
                             <!-- ไฟล์ที่เลือกจะแสดงที่นี่ -->

--- a/src/controllers/apiController.ts
+++ b/src/controllers/apiController.ts
@@ -4023,7 +4023,7 @@ apiRouter.get('/groups/:groupId/tasks', validateRequest(taskSchemas.list), apiCo
 apiRouter.post('/groups/:groupId/tasks', validateRequest(taskSchemas.create), apiController.createTask.bind(apiController));
 apiRouter.get('/groups/:groupId/calendar', apiController.getCalendarEvents.bind(apiController));
 // Group file listing should respect the requested group rather than defaulting to "default"
-apiRouter.get('/groups/:groupId/files', apiController.getGroupFiles.bind(apiController));
+apiRouter.get('/groups/:groupId/files', (req, res) => apiController.getGroupFiles(req, res));
 apiRouter.get('/groups/:groupId/leaderboard', apiController.getLeaderboard.bind(apiController));
 apiRouter.post('/groups/:groupId/sync-leaderboard', apiController.syncLeaderboard.bind(apiController));
 apiRouter.get('/users/:userId/score-history/:groupId', apiController.getUserScoreHistory.bind(apiController));
@@ -4126,7 +4126,7 @@ apiRouter.get('/groups/:groupId/tasks/:taskId',
 apiRouter.get('/tasks/:groupId', apiController.getTasks.bind(apiController));
 apiRouter.post('/tasks/:groupId', apiController.createTask.bind(apiController));
 apiRouter.get('/calendar/:groupId', apiController.getCalendarEvents.bind(apiController));
-apiRouter.get('/files/:groupId', apiController.getFiles.bind(apiController));
+apiRouter.get('/files/:groupId', (req, res) => apiController.getGroupFiles(req, res));
 apiRouter.get('/leaderboard/:groupId', apiController.getLeaderboard.bind(apiController));
 
   // Debug endpoint for recurring tasks


### PR DESCRIPTION
## Summary
- route both legacy and new group file endpoints through getGroupFiles to respect the requested group
- enforce task/file relationship updates from the owning Task.attachedFiles side with group validation
- refresh dashboard caching, submission, and download flows so attachments sync correctly across desktop/mobile

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68df6b2ade4483329f5b5c99a3eae265