### PR TITLE
Add attachment summary chip in task detail modal

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -995,6 +995,7 @@
                         <span id="taskDetailPriority" class="px-3 py-1 rounded-full text-sm font-medium">ความสำคัญ</span>
                         <span id="taskDetailCategory" class="px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-700">หมวดหมู่</span>
                     </div>
+                    <div id="taskDetailAttachmentSummary" class="hidden mb-6"></div>
                 </div>
 
                 <!-- Task Details Grid -->


### PR DESCRIPTION
## Summary
- show an attachment summary chip near the top of the task detail modal when files are available
- add client-side helpers to render the summary, scroll to the attachment section, and hide it when no files exist
- ensure attachment summary updates with API results alongside the existing attachment list

## Testing
- npm run lint *(fails: ESLint config missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f62e85748332bdaa8a8d32117cac