### PR TITLE
Fix bottom navigation overlapping content on mobile

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -451,7 +451,7 @@
         </aside>
 
         <!-- Main Content -->
-        <main class="flex-1 overflow-auto">
+        <main class="flex-1 overflow-auto app-main pb-24 md:pb-0">
             <!-- Current User Badge (shows when userId present) -->
             <div id="currentUserBadge" class="hidden fixed top-3 right-3 z-50 bg-white border border-gray-200 shadow rounded-full px-3 py-1 flex items-center gap-2 text-sm text-gray-700">
                 <span id="currentUserAvatar" class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 text-blue-700 font-semibold">L</span>

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -12,6 +12,16 @@ body {
   background-color: #f9fafb;
 }
 
+.app-main {
+  padding-bottom: 0;
+}
+
+@media (max-width: 767px) {
+  .app-main {
+    padding-bottom: 96px;
+  }
+}
+
 /* Content sections */
 .content-section {
   display: none;


### PR DESCRIPTION
## Summary
- add a dedicated main container class with responsive padding to avoid the mobile bottom navigation covering content
- apply Tailwind padding utilities and a CSS fallback so the main area always clears the fixed navigation bar on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e309221c108332a485947cd087f44f