### PR TITLE
Add recurring tasks shortcut to mobile navigation

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -943,6 +943,10 @@
             <i class="fas fa-tasks"></i>
             <span>งาน</span>
         </a>
+        <a href="#recurring" class="bottom-nav-item" data-view="recurring">
+            <i class="fas fa-clock"></i>
+            <span>งานประจำ</span>
+        </a>
         <a href="#files" class="bottom-nav-item" data-view="files">
             <i class="fas fa-folder"></i>
             <span>ไฟล์</span>


### PR DESCRIPTION
## Summary
- add the recurring tasks link to the mobile bottom navigation bar so the page is accessible on small screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30b8b70708332b8bd28c327d6f096